### PR TITLE
fix: stop treating HTTP 304 as a feed error (#9)

### DIFF
--- a/src/crawler/fetcher.rs
+++ b/src/crawler/fetcher.rs
@@ -20,16 +20,13 @@ pub struct FetchResult {
     pub content_type: Option<String>,
 }
 
-/// Result of fetching recipe content with conditional request support
+/// Outcome of a conditional fetch.
+///
+/// A 304 is the expected, healthy answer when our cached validators are still
+/// current - it is not an error, and callers must not treat it as one.
 #[derive(Debug)]
-pub enum RecipeContentResult {
-    /// Content was fetched (new or modified)
-    Fetched {
-        content: String,
-        etag: Option<String>,
-        last_modified: Option<String>,
-    },
-    /// Content not modified (304 response)
+pub enum FetchOutcome {
+    Fetched(FetchResult),
     NotModified,
 }
 
@@ -50,9 +47,15 @@ impl Fetcher {
         })
     }
 
-    /// Fetch a URL with retry logic and exponential backoff
+    /// Fetch a URL unconditionally, with retry logic and exponential backoff
     pub async fn fetch(&self, url: &str) -> Result<FetchResult> {
-        self.fetch_with_conditions(url, None, None).await
+        match self.fetch_with_conditions(url, None, None).await? {
+            FetchOutcome::Fetched(result) => Ok(result),
+            // No validators were sent, so a 304 here means the server is broken.
+            FetchOutcome::NotModified => Err(Error::FeedParse(
+                "server returned 304 to an unconditional request".to_string(),
+            )),
+        }
     }
 
     /// Fetch a URL with conditional request headers (ETag, Last-Modified)
@@ -61,13 +64,13 @@ impl Fetcher {
         url: &str,
         etag: Option<&str>,
         last_modified: Option<&str>,
-    ) -> Result<FetchResult> {
+    ) -> Result<FetchOutcome> {
         let mut retries = 0;
         let mut backoff = self.initial_backoff;
 
         loop {
             match self.fetch_once(url, etag, last_modified).await {
-                Ok(result) => return Ok(result),
+                Ok(outcome) => return Ok(outcome),
                 Err(e) if retries < self.max_retries && Self::is_retryable(&e) => {
                     retries += 1;
                     warn!(
@@ -87,7 +90,7 @@ impl Fetcher {
         url: &str,
         etag: Option<&str>,
         last_modified: Option<&str>,
-    ) -> Result<FetchResult> {
+    ) -> Result<FetchOutcome> {
         debug!("Fetching: {}", url);
 
         let mut request = self.client.get(url);
@@ -103,9 +106,10 @@ impl Fetcher {
 
         let response = request.send().await?;
 
-        // Handle 304 Not Modified
+        // 304 means our cached copy is still current - a success, not a failure
         if response.status() == StatusCode::NOT_MODIFIED {
-            return Err(Error::FeedParse("304 Not Modified".to_string()));
+            debug!("Not modified: {}", url);
+            return Ok(FetchOutcome::NotModified);
         }
 
         // Check for success status
@@ -167,12 +171,12 @@ impl Fetcher {
         // Read response body with size limit
         let content = self.read_with_limit(response).await?;
 
-        Ok(FetchResult {
+        Ok(FetchOutcome::Fetched(FetchResult {
             content,
             etag: new_etag,
             last_modified: new_last_modified,
             content_type,
-        })
+        }))
     }
 
     async fn read_with_limit(&self, response: Response) -> Result<String> {
@@ -201,27 +205,14 @@ impl Fetcher {
             _ => false,
         }
     }
+}
 
-    /// Fetch recipe content with conditional request support
-    /// Returns NotModified if the content hasn't changed (304 response)
-    pub async fn fetch_recipe_content(
-        &self,
-        url: &str,
-        etag: Option<&str>,
-        last_modified: Option<&str>,
-    ) -> Result<RecipeContentResult> {
-        match self.fetch_with_conditions(url, etag, last_modified).await {
-            Ok(result) => Ok(RecipeContentResult::Fetched {
-                content: result.content,
-                etag: result.etag,
-                last_modified: result.last_modified,
-            }),
-            Err(Error::FeedParse(msg)) if msg == "304 Not Modified" => {
-                Ok(RecipeContentResult::NotModified)
-            }
-            Err(e) => Err(e),
-        }
-    }
+/// Format a timestamp as an HTTP-date (IMF-fixdate), the only format a server is
+/// required to accept in `If-Modified-Since` (RFC 9110 5.6.7). Neither
+/// `to_rfc3339` nor chrono's `to_rfc2822` produces it: the latter renders the
+/// zone as `+0000` instead of `GMT`.
+pub fn http_date(dt: &chrono::DateTime<chrono::Utc>) -> String {
+    dt.format("%a, %d %b %Y %H:%M:%S GMT").to_string()
 }
 
 /// Rate limiter for respecting crawl delays
@@ -290,5 +281,19 @@ mod tests {
     fn test_fetcher_creation() {
         let fetcher = Fetcher::new("TestBot/1.0".to_string(), 5_242_880);
         assert!(fetcher.is_ok());
+    }
+
+    #[test]
+    fn http_date_renders_imf_fixdate() {
+        let dt = chrono::DateTime::parse_from_rfc3339("2026-04-15T10:22:42Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        assert_eq!(http_date(&dt), "Wed, 15 Apr 2026 10:22:42 GMT");
+
+        // The formats previously sent on If-Modified-Since. RFC 3339 is not an
+        // HTTP-date at all; RFC 2822 renders the zone as "+0000", not "GMT".
+        assert_ne!(http_date(&dt), dt.to_rfc3339());
+        assert_ne!(http_date(&dt), dt.to_rfc2822());
     }
 }

--- a/src/crawler/mod.rs
+++ b/src/crawler/mod.rs
@@ -10,7 +10,7 @@ use crate::db::{self, models::*, DbPool};
 use crate::error::{Error, Result};
 use crate::indexer::parse_cooklang_full;
 use crate::utils::validation;
-use fetcher::{Fetcher, RateLimiter, RecipeContentResult};
+use fetcher::{http_date, FetchOutcome, Fetcher, RateLimiter};
 use parser::{parse_feed, ParsedEntry};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -77,14 +77,23 @@ impl Crawler {
             .fetch_with_conditions(
                 feed_url,
                 feed.etag.as_deref(),
-                feed.last_modified
-                    .as_ref()
-                    .map(|dt| dt.to_rfc3339())
-                    .as_deref(),
+                feed.last_modified.as_ref().map(http_date).as_deref(),
             )
             .await
         {
-            Ok(result) => result,
+            Ok(FetchOutcome::Fetched(result)) => result,
+            Ok(FetchOutcome::NotModified) => {
+                // The feed is healthy, it just has nothing new for us.
+                info!("Feed {} unchanged since last crawl (304)", feed_url);
+                db::feeds::mark_feed_unchanged(pool, feed.id).await?;
+
+                return Ok(CrawlResult {
+                    feed_id: feed.id,
+                    new_recipes: 0,
+                    updated_recipes: 0,
+                    skipped_recipes: 0,
+                });
+            }
             Err(e) => {
                 error!("Failed to fetch feed {}: {}", feed_url, e);
                 db::feeds::increment_error_count(pool, feed.id).await?;
@@ -267,27 +276,23 @@ impl Crawler {
                 // Use conditional request with stored caching headers
                 let result = self
                     .fetcher
-                    .fetch_recipe_content(
+                    .fetch_with_conditions(
                         enclosure_url,
                         recipe.content_etag.as_deref(),
                         recipe
                             .content_last_modified
                             .as_ref()
-                            .map(|dt| dt.to_rfc2822())
+                            .map(http_date)
                             .as_deref(),
                     )
                     .await;
 
                 match result {
-                    Ok(RecipeContentResult::Fetched {
-                        content,
-                        etag,
-                        last_modified,
-                    }) => {
+                    Ok(FetchOutcome::Fetched(fetched)) => {
                         debug!("Fetched updated content for {}", entry.id);
-                        (Some(content), etag, last_modified)
+                        (Some(fetched.content), fetched.etag, fetched.last_modified)
                     }
-                    Ok(RecipeContentResult::NotModified) => {
+                    Ok(FetchOutcome::NotModified) => {
                         // Content unchanged, just update the feed_entry_updated timestamp
                         debug!("Content not modified for {} (304)", entry.id);
                         db::recipes::update_feed_entry_timestamp(
@@ -311,16 +316,18 @@ impl Crawler {
                 // New recipe, fetch without conditional headers
                 match self
                     .fetcher
-                    .fetch_recipe_content(enclosure_url, None, None)
+                    .fetch_with_conditions(enclosure_url, None, None)
                     .await
                 {
-                    Ok(RecipeContentResult::Fetched {
-                        content,
-                        etag,
-                        last_modified,
-                    }) => (Some(content), etag, last_modified),
-                    Ok(RecipeContentResult::NotModified) => {
+                    Ok(FetchOutcome::Fetched(fetched)) => {
+                        (Some(fetched.content), fetched.etag, fetched.last_modified)
+                    }
+                    Ok(FetchOutcome::NotModified) => {
                         // Shouldn't happen without conditional headers, but handle gracefully
+                        warn!(
+                            "Server returned 304 for {} despite no conditional headers",
+                            enclosure_url
+                        );
                         (None, None, None)
                     }
                     Err(e) => {
@@ -433,56 +440,10 @@ impl Crawler {
         limiter.wait().await;
     }
 
-    /// Fetch feed with conditional requests for scheduler
-    pub async fn fetch_feed(
-        &self,
-        url: &str,
-        etag: Option<&str>,
-        last_modified: Option<&chrono::DateTime<chrono::Utc>>,
-    ) -> Result<FetchedFeed> {
-        let last_modified_str = last_modified.map(|dt| dt.to_rfc2822());
-
-        match self
-            .fetcher
-            .fetch_with_conditions(url, etag, last_modified_str.as_deref())
-            .await
-        {
-            Ok(result) => {
-                let last_modified = result
-                    .last_modified
-                    .and_then(|s| chrono::DateTime::parse_from_rfc2822(&s).ok())
-                    .map(|dt| dt.with_timezone(&chrono::Utc));
-
-                Ok(FetchedFeed {
-                    content: result.content,
-                    etag: result.etag,
-                    last_modified,
-                    modified: true,
-                })
-            }
-            Err(Error::FeedParse(msg)) if msg == "304 Not Modified" => Ok(FetchedFeed {
-                content: String::new(),
-                etag: None,
-                last_modified: None,
-                modified: false,
-            }),
-            Err(e) => Err(e),
-        }
-    }
-
     /// Parse feed content
     pub fn parse_feed(&self, content: &str) -> Result<parser::ParsedFeed> {
         parser::parse_feed(content)
     }
-}
-
-/// Feed fetch result for scheduler
-#[derive(Debug)]
-pub struct FetchedFeed {
-    pub content: String,
-    pub etag: Option<String>,
-    pub last_modified: Option<chrono::DateTime<chrono::Utc>>,
-    pub modified: bool,
 }
 
 #[derive(Debug)]

--- a/src/crawler/scheduler.rs
+++ b/src/crawler/scheduler.rs
@@ -53,9 +53,10 @@ impl Scheduler {
         let mut total_feeds = 0;
 
         loop {
-            // Fetch feeds in batches
-            let feeds =
-                db::feeds::list_feeds(&self.pool, Some("active"), BATCH_SIZE, offset).await?;
+            // Fetch feeds in batches. This includes feeds currently in `error`:
+            // failures are usually transient, and skipping them would make a
+            // single bad response permanent.
+            let feeds = db::feeds::list_crawlable_feeds(&self.pool, BATCH_SIZE, offset).await?;
 
             if feeds.is_empty() {
                 break;

--- a/src/db/feeds.rs
+++ b/src/db/feeds.rs
@@ -120,6 +120,31 @@ pub async fn list_feeds_with_filter(
     Ok(feeds)
 }
 
+/// List the feeds the crawler should poll: everything except the ones that were
+/// deliberately switched off.
+///
+/// `error` feeds are included on purpose. A fetch failure is usually transient
+/// (server hiccup, timeout), so excluding them would make a single bad response
+/// permanent - the feed would never be retried and would go stale forever.
+/// A feed that recovers is flipped back to `active` by the crawler.
+pub async fn list_crawlable_feeds(pool: &DbPool, limit: i64, offset: i64) -> Result<Vec<Feed>> {
+    let feeds = sqlx::query_as::<_, Feed>(
+        r#"
+        SELECT f.* FROM feeds f
+        LEFT JOIN github_feeds gf ON f.id = gf.feed_id
+        WHERE f.status IN ('active', 'error') AND gf.id IS NULL
+        ORDER BY f.created_at DESC
+        LIMIT ? OFFSET ?
+        "#,
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(feeds)
+}
+
 /// Count feeds
 pub async fn count_feeds(pool: &DbPool, status: Option<&str>) -> Result<i64> {
     let count = if let Some(status) = status {
@@ -218,6 +243,31 @@ pub async fn update_feed_fetch_info(
     Ok(())
 }
 
+/// Record a successful poll that returned 304 Not Modified.
+///
+/// The feed is healthy and unchanged, so this clears any earlier error state but
+/// leaves `etag`/`last_modified` untouched - those validators are what produced
+/// the 304, and clearing them would make the next request unconditional.
+pub async fn mark_feed_unchanged(pool: &DbPool, feed_id: i64) -> Result<()> {
+    let now = Utc::now();
+
+    sqlx::query(
+        r#"
+        UPDATE feeds
+        SET last_fetched_at = ?, status = 'active', error_count = 0,
+            error_message = NULL, updated_at = ?
+        WHERE id = ?
+        "#,
+    )
+    .bind(now)
+    .bind(now)
+    .bind(feed_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 /// Increment feed error count
 pub async fn increment_error_count(pool: &DbPool, feed_id: i64) -> Result<()> {
     sqlx::query("UPDATE feeds SET error_count = error_count + 1 WHERE id = ?")
@@ -284,5 +334,77 @@ mod tests {
         delete_feed(&pool, feed.id).await.unwrap();
         let count = count_feeds(&pool, None).await.unwrap();
         assert_eq!(count, 0);
+    }
+
+    async fn seed_feed(pool: &DbPool, url: &str, status: &str) -> Feed {
+        let feed = create_feed(
+            pool,
+            &NewFeed {
+                url: url.to_string(),
+                title: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        update_feed_status(pool, feed.id, status, 3, Some("boom".to_string()))
+            .await
+            .unwrap();
+
+        get_feed(pool, feed.id).await.unwrap()
+    }
+
+    /// A feed that failed once must be retried on the next scheduler tick.
+    /// Previously the scheduler only listed `active` feeds, so `error` was a
+    /// terminal state and the feed was never crawled again (issue #9).
+    #[tokio::test]
+    async fn list_crawlable_feeds_retries_errored_feeds_but_skips_disabled() {
+        let pool = init_pool("sqlite::memory:").await.unwrap();
+        run_migrations(&pool).await.unwrap();
+
+        seed_feed(&pool, "https://example.com/active.xml", "active").await;
+        seed_feed(&pool, "https://example.com/errored.xml", "error").await;
+        seed_feed(&pool, "https://example.com/disabled.xml", "disabled").await;
+
+        let feeds = list_crawlable_feeds(&pool, 50, 0).await.unwrap();
+
+        let urls: Vec<&str> = feeds.iter().map(|f| f.url.as_str()).collect();
+        assert!(urls.contains(&"https://example.com/active.xml"));
+        assert!(
+            urls.contains(&"https://example.com/errored.xml"),
+            "errored feeds must be retried, otherwise a single failure is permanent"
+        );
+        assert!(
+            !urls.contains(&"https://example.com/disabled.xml"),
+            "disabled feeds are switched off deliberately and must stay off"
+        );
+    }
+
+    /// A 304 Not Modified means the feed is healthy and unchanged: record the
+    /// fetch attempt, clear any previous error state, and keep the cached
+    /// validators so the next conditional request still works.
+    #[tokio::test]
+    async fn mark_feed_unchanged_clears_error_state_and_keeps_validators() {
+        let pool = init_pool("sqlite::memory:").await.unwrap();
+        run_migrations(&pool).await.unwrap();
+
+        let feed = seed_feed(&pool, "https://example.com/feed.xml", "error").await;
+        let modified = Utc::now();
+        update_feed_fetch_info(&pool, feed.id, Some("\"etag-v1\""), Some(modified))
+            .await
+            .unwrap();
+
+        mark_feed_unchanged(&pool, feed.id).await.unwrap();
+
+        let feed = get_feed(&pool, feed.id).await.unwrap();
+        assert_eq!(feed.status, "active");
+        assert_eq!(feed.error_count, 0);
+        assert_eq!(feed.error_message, None);
+        assert_eq!(
+            feed.etag.as_deref(),
+            Some("\"etag-v1\""),
+            "the cached ETag must survive a 304, or the next request can't be conditional"
+        );
+        assert!(feed.last_fetched_at.is_some());
     }
 }

--- a/tests/conditional_request_test.rs
+++ b/tests/conditional_request_test.rs
@@ -1,0 +1,113 @@
+//! Conditional HTTP request handling (issue #9).
+//!
+//! A 304 Not Modified is the *expected* response when we send If-None-Match /
+//! If-Modified-Since to a server whose content hasn't changed. It must be a
+//! normal outcome, never an error - otherwise well-behaved feeds get marked
+//! broken on the first crawl after a successful one.
+
+use federation::crawler::fetcher::{FetchOutcome, Fetcher};
+
+fn fetcher() -> Fetcher {
+    Fetcher::new("FederationTest/1.0".to_string(), 5_242_880).unwrap()
+}
+
+#[tokio::test]
+async fn returns_not_modified_when_server_answers_304_to_if_none_match() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/feed.xml")
+        .match_header("if-none-match", "\"etag-v1\"")
+        .with_status(304)
+        .create_async()
+        .await;
+
+    let outcome = fetcher()
+        .fetch_with_conditions(
+            &format!("{}/feed.xml", server.url()),
+            Some("\"etag-v1\""),
+            None,
+        )
+        .await
+        .expect("304 is a normal conditional-request outcome, not a fetch error");
+
+    assert!(
+        matches!(outcome, FetchOutcome::NotModified),
+        "expected NotModified, got {outcome:?}"
+    );
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn returns_not_modified_when_server_answers_304_to_if_modified_since() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/feed.xml")
+        .match_header("if-modified-since", "Wed, 15 Apr 2026 10:22:42 GMT")
+        .with_status(304)
+        .create_async()
+        .await;
+
+    let outcome = fetcher()
+        .fetch_with_conditions(
+            &format!("{}/feed.xml", server.url()),
+            None,
+            Some("Wed, 15 Apr 2026 10:22:42 GMT"),
+        )
+        .await
+        .expect("304 is a normal conditional-request outcome, not a fetch error");
+
+    assert!(matches!(outcome, FetchOutcome::NotModified));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn returns_fetched_content_with_caching_headers_on_200() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/feed.xml")
+        .with_status(200)
+        .with_header("content-type", "application/atom+xml")
+        .with_header("etag", "\"etag-v2\"")
+        .with_header("last-modified", "Wed, 15 Apr 2026 10:22:42 GMT")
+        .with_body("<feed/>")
+        .create_async()
+        .await;
+
+    let outcome = fetcher()
+        .fetch_with_conditions(&format!("{}/feed.xml", server.url()), None, None)
+        .await
+        .unwrap();
+
+    match outcome {
+        FetchOutcome::Fetched(result) => {
+            assert_eq!(result.content, "<feed/>");
+            assert_eq!(result.etag.as_deref(), Some("\"etag-v2\""));
+            assert_eq!(
+                result.last_modified.as_deref(),
+                Some("Wed, 15 Apr 2026 10:22:42 GMT")
+            );
+        }
+        FetchOutcome::NotModified => panic!("expected Fetched, got NotModified"),
+    }
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn real_http_errors_are_still_errors() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/feed.xml")
+        .with_status(500)
+        .create_async()
+        .await;
+
+    let result = fetcher()
+        .fetch_with_conditions(&format!("{}/feed.xml", server.url()), None, None)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a 500 must still surface as an error so the feed is marked unhealthy"
+    );
+    mock.assert_async().await;
+}


### PR DESCRIPTION
Fixes #9.

## What was broken

Two bugs compounded into a feed that dies permanently and silently.

**A 304 was treated as a fetch failure.** `fetcher.rs` turned HTTP 304 into `Err(Error::FeedParse("304 Not Modified"))` — smuggling a *success* through the error type, identified downstream by string matching. `crawl_feed` never did that string match, so a healthy 304 fell into its generic error handler and set `status = "error"`.

**Errored feeds were never retried.** The scheduler only listed feeds with `status = "active"`, making `"error"` a terminal state. Only a process restart unstuck a feed, because config sync resets the status on boot.

Together: every feed whose server correctly honours ETags gets bricked on the first crawl after a successful one. That is exactly the log in #9 — 13:38 success (stores ETag) → 14:38 conditional request → 304 → error → silence.

The smoking gun: `Crawler::fetch_feed` was the *only* function that handled 304 correctly, and it had **zero callers**. Dead code. The live path through `crawl_feed` had simply forgotten the case, and the dead duplicate made it look handled.

## The fix

- `fetch_with_conditions` now returns `FetchOutcome::{Fetched, NotModified}` instead of `Result<FetchResult>`, so the **compiler forces every caller to confront the 304 case**. Adding a third string-match would have repeated the exact fragility that caused this.
- On 304 the crawler records a healthy no-op poll via `mark_feed_unchanged`, which clears stale error state but deliberately **preserves `etag`/`last_modified`** — clearing them would make the next request unconditional.
- The scheduler polls via `list_crawlable_feeds`, which **includes `error` feeds** so transient failures self-heal, while still excluding deliberately `disabled` ones.
- Deleted the dead `fetch_feed`/`FetchedFeed` pair.

One adjacent bug fixed because it lives in the same call: `crawl_feed` sent `If-Modified-Since` as RFC 3339, which is not a valid HTTP-date at all, and the recipe path used chrono's `to_rfc2822`, which renders the zone as `+0000` instead of `GMT`. Servers were ignoring the header, so feeds without an ETag re-downloaded every hour. Both now use a proper IMF-fixdate helper.

## Tests

Four mockito integration tests in `tests/conditional_request_test.rs`: 304-via-ETag, 304-via-Last-Modified, a normal 200 with caching headers, and confirmation that a 500 **still** errors so genuinely broken feeds are still flagged. Plus DB tests pinning the retry-errored-but-skip-disabled selection and the 304 bookkeeping.

SSRF validation blocks loopback URLs (`validation.rs:70`), so `crawl_feed` cannot be driven end-to-end against a mock server — I tested the two real seams instead rather than weaken that check for tests.

Full suite passes (80 tests), clippy and rustfmt clean.

## Deployment

**No migration needed.** Feeds currently stuck in `error` are picked up automatically on the next scheduler tick.